### PR TITLE
Fix num_desired_heroku_workers not returning integers.

### DIFF
--- a/lib/heroku_resque_autoscaler.rb
+++ b/lib/heroku_resque_autoscaler.rb
@@ -55,5 +55,7 @@ module HerokuResqueAutoscaler
         return scale_info[:workers]
       end
     end
+
+    0
   end
 end

--- a/spec/lib/heroku_resque_autoscaler/scaler_spec.rb
+++ b/spec/lib/heroku_resque_autoscaler/scaler_spec.rb
@@ -96,6 +96,14 @@ describe HerokuResqueAutoscaler do
       HerokuResqueAutoscaler::Scaler.stub(:job_count).and_return(num_jobs)
       HerokuResqueAutoscalerTestClass.num_desired_heroku_workers.should == 5
     end
+
+    context "when Scaler.job_count returns 0" do
+      it "returns 0" do
+        num_jobs = 0
+        HerokuResqueAutoscaler::Scaler.stub(:job_count).and_return(num_jobs)
+        HerokuResqueAutoscalerTestClass.num_desired_heroku_workers.should == 0
+      end
+    end
   end
 
   context ".after_perform_scale_down" do


### PR DESCRIPTION
With fast resque jobs and multiple workers, we've seen an edge case
where `#num_desired_heroku_workers` returns the WORKER_SCALE array instead
of a number.  Somehow the `Scale.job_count` is zero despite having just
enqueued a job, so our theory is that another worker has already grabbed
the job from the queue while the API call was happening.
