### PR TITLE
updates resque version in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Inspired by [@darkhelmet](https://github.com/darkhelmet)'s
 ## Requirements
 
 * ["heroku_api", "~> 0.3.5"](http://rubygems.org/gems/heroku-api)
-* ["resque", "~> 1.23.0"](http://rubygems.org/gems/resque)
+* ["resque", "~> 1.25.1"](http://rubygems.org/gems/resque)
 
 
 ## Installation

--- a/heroku_resque_autoscaler.gemspec
+++ b/heroku_resque_autoscaler.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "heroku-api", "~> 0.3.5"
-  gem.add_dependency "resque", "~> 1.23.0"
+  gem.add_dependency "resque", "~> 1.25.1"
 
   gem.add_development_dependency "simplecov", "~> 0.7.1"
   gem.add_development_dependency "rspec", "~> 2.11.0"


### PR DESCRIPTION
Couldn't use this gem until I installed the depreciated version of the resque gem or updated the resque version to be current here- all specs pass with update.
