### PR TITLE
Retry after a delay if the API rate limit is hit

### DIFF
--- a/lib/heroku_resque_autoscaler/configuration.rb
+++ b/lib/heroku_resque_autoscaler/configuration.rb
@@ -3,6 +3,8 @@ module HerokuResqueAutoscaler
     OPTIONS = {
       heroku_api_key: ENV["HEROKU_API_KEY"],
       heroku_app_name: ENV["HEROKU_APP_NAME"],
+      heroku_max_retry: ENV["HEROKU_MAX_RETRY"] ||= "5",
+      heroku_retry_rate: ENV["HEROKU_RETRY_RATE"] ||= "10"
     }
 
     # Defines accessors for all OPTIONS


### PR DESCRIPTION
Instead of scaling, or failing nicely we were just blowing up if the API
limit is hit.  This way it will retry a few times and hopefully work.
Though it does not fix the problem of to many API calls in general and
could make the problem worse with retrying.

This looks a bit ugly to me, but I wanted to get something out there to fix the immediate problem.